### PR TITLE
Use a preferred AnyObject keyword

### DIFF
--- a/MileusWatchdogKit/Market Validation/MileusMarketValidationFlowDelegate.swift
+++ b/MileusWatchdogKit/Market Validation/MileusMarketValidationFlowDelegate.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 
-public protocol MileusMarketValidationFlowDelegate: class {
+public protocol MileusMarketValidationFlowDelegate: AnyObject {
     
     func mileusDidFinish(_ mileus: MileusMarketValidation)
     

--- a/MileusWatchdogKit/Scheduling/MileusWatchdogSchedulerFlowDelegate.swift
+++ b/MileusWatchdogKit/Scheduling/MileusWatchdogSchedulerFlowDelegate.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 
-public protocol MileusWatchdogSchedulerFlowDelegate: class {
+public protocol MileusWatchdogSchedulerFlowDelegate: AnyObject {
     
     func mileusDidFinish(_ mileus: MileusWatchdogScheduler)
     func mileus(_ mileus: MileusWatchdogScheduler, showSearch data: MileusWatchdogSearchData)

--- a/MileusWatchdogKit/Search/MileusWatchdogSearchFlowDelegate.swift
+++ b/MileusWatchdogKit/Search/MileusWatchdogSearchFlowDelegate.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 
-public protocol MileusWatchdogSearchFlowDelegate: class {
+public protocol MileusWatchdogSearchFlowDelegate: AnyObject {
     
     func mileus(_ mileus: MileusWatchdogSearch, showSearch data: MileusWatchdogSearchData)
     func mileusShowTaxiRide(_ mileus: MileusWatchdogSearch)

--- a/MileusWatchdogKit/Views/NavigationBarWebDelegate.swift
+++ b/MileusWatchdogKit/Views/NavigationBarWebDelegate.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 
-protocol NavigationBarWebDelegate: class {
+protocol NavigationBarWebDelegate: AnyObject {
     func setTitle(title: String?)
     func setInfoButton(viewModel: InfoButtonViewModel?)
 }


### PR DESCRIPTION
Replaced occurrences of `class` with `AnyObject` in protocol conformance.